### PR TITLE
Fix direction of swipe strings

### DIFF
--- a/res/values/lineage_strings.xml
+++ b/res/values/lineage_strings.xml
@@ -78,7 +78,7 @@
     <!-- Settings title to show Google Now at -1 screen on launcher. [CHAR LIMIT=50] -->
     <string name="title_show_google_app">Show Google app</string>
     <!-- Settings message explaining when the -1 screen is available on an LTR device. [CHAR LIMIT=100] -->
-    <string name="msg_minus_one_on_left">When you swipe left from main homescreen</string>
+    <string name="msg_minus_one_on_left">When you swipe right from main homescreen</string>
     <!-- Settings message explaining when the -1 screen is available on an RTL device. [CHAR LIMIT=100] -->
-    <string name="msg_minus_one_on_right">When you swipe right from main homescreen</string>
+    <string name="msg_minus_one_on_right">When you swipe left from main homescreen</string>
 </resources>


### PR DESCRIPTION
On a LTR system the -1 page is on the left, so you need to swipe
to the right to access it.

Change-Id: I092f5ed1a27045f8a42b62b93f74c4d3f278d6d7